### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-docker-image-on-push.yml
+++ b/.github/workflows/build-docker-image-on-push.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Github Docker registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: robinj1995/robinj.be/website
           registry: ghcr.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore